### PR TITLE
Create intermediate directories in ConfigFile

### DIFF
--- a/hydroshare_on_jupyter/config_setup.py
+++ b/hydroshare_on_jupyter/config_setup.py
@@ -38,7 +38,7 @@ class ConfigFile(BaseSettings):
                 f"Configuration path: {str(path)} is a file not a directory."
             )
         elif not path.exists():
-            path.mkdir()
+            path.mkdir(parents=True)
         return path
 
     @validator("oauth_path")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 # define package name globally
 PKGNAME = "hydroshare_on_jupyter"
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 
 # define webapp path globally
 here = Path(__file__).resolve().parent

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,22 @@
 import pytest
 import pickle
 from hydroshare_on_jupyter.config_setup import ConfigFile, FileNotDirectoryError
-from tempfile import TemporaryDirectory, TemporaryFile
+from tempfile import TemporaryDirectory
 from pathlib import Path
 
+TEST_CONFIG_FILE_CASES = ("logs", "dir_that_does_not_exist/logs")
 
-def test_config_file():
+
+@pytest.mark.parametrize("log_dir", TEST_CONFIG_FILE_CASES)
+def test_config_file(log_dir: str):
     with TemporaryDirectory() as temp:
-        log = Path(temp) / "logs"
+        log = Path(temp) / log_dir
+        ConfigFile(data_path=temp, log_path=log)
+
+
+def test_config_creatifile():
+    with TemporaryDirectory() as temp:
+        log = Path(temp) / "dir_that_does_not_exist" / "logs"
         ConfigFile(data_path=temp, log_path=log)
 
 


### PR DESCRIPTION
fixes #92

version bumped to `0.1.4`

## Changes

- `ConfigFile` now creates intermediate directories for logging and data directories if they do not already exist.

